### PR TITLE
Supports headers and omitting hours

### DIFF
--- a/syntaxes/vtt.tmLanguage.json
+++ b/syntaxes/vtt.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "WebVTT",
-  "firstLineMatch": "^WEBVTT$",
+  "firstLineMatch": "^WEBVTT([ \t].+)?$",
   "patterns": [
     { "include": "#doctype" },
     { "include": "#comment" },
@@ -15,7 +15,7 @@
       "name": "constant.numeric"
     },
     "doctype": {
-      "patterns": [{ "name": "keyword.control", "match": "^WEBVTT$" }]
+      "patterns": [{ "name": "keyword.control", "match": "^WEBVTT([ \t].+)?$", "captures": {"1": { "name": "comment.header" } } }]
     },
     "comment": {
       "patterns": [

--- a/syntaxes/vtt.tmLanguage.json
+++ b/syntaxes/vtt.tmLanguage.json
@@ -68,7 +68,7 @@
     "timeline": {
       "patterns": [
         {
-          "begin": "^(\\d{2}:\\d{2}:\\d{2}.\\d{3}) (-->) (\\d{2}:\\d{2}:\\d{2}.\\d{3})( region(:)(.*))?$",
+          "begin": "^((?:\\d{2}:)?\\d{2}:\\d{2}.\\d{3}) (-->) ((?:\\d{2}:)?\\d{2}:\\d{2}.\\d{3})( region(:)(.*))?$",
           "end": "^\\n",
           "patterns": [{ "include": "#metadata" }, { "include": "#vtt-html" }],
           "beginCaptures": {

--- a/testfiles/example2.vtt
+++ b/testfiles/example2.vtt
@@ -1,1 +1,4 @@
 WEBVTT - text header
+
+00:00.000 --> 00:08.000
+Optional if the hours is zero.

--- a/testfiles/example2.vtt
+++ b/testfiles/example2.vtt
@@ -1,0 +1,1 @@
+WEBVTT - text header


### PR DESCRIPTION
### Allow text header

> [4.1. WebVTT file structure](https://www.w3.org/TR/webvtt1/#file-structure)
>
> A WebVTT file body consists of the following components, in the following order:
> 1. An optional U+FEFF BYTE ORDER MARK (BOM) character.
> 2. The string "WEBVTT".
> 3. Optionally, either a U+0020 SPACE character or a U+0009 CHARACTER TABULATION (tab) character followed by any number of characters that are not U+000A LINE FEED (LF) or U+000D CARRIAGE RETURN (CR) characters.

### Optional if the hours is zero

> [4.1. WebVTT file structure](https://www.w3.org/TR/webvtt1/#webvtt-timestamp)
>
> A WebVTT timestamp consists of the following components, in the given order:
> 1. Optionally (required if hours is non-zero):
>     1. Two or more ASCII digits, representing the hours as a base ten integer.
>     2. A U+003A COLON character (:)
> 